### PR TITLE
Fix AutoSizeLabel min_size behavior to allow changes

### DIFF
--- a/addons/FreeControl/src/SizeController/AutoSizeLabel/AutoSizeLabel.gd
+++ b/addons/FreeControl/src/SizeController/AutoSizeLabel/AutoSizeLabel.gd
@@ -48,7 +48,7 @@ const MIN_FONT_SIZE := 1
 		val = clampi(val, MIN_FONT_SIZE, max_size)
 		
 		if min_size != val:
-			min_size = max_size
+			min_size = val
 			_update_font_size_check()
 
 @export_group("Options")


### PR DESCRIPTION
Hello,

I found a bug (I guess) with AutoSizeLabel, where you couldn't really change the `min_size`'s value or at most once :) and here is a simple fix. Since it's using 
`val = clampi(val, MIN_FONT_SIZE, max_size)`
it won't get over `max_size` or below `MIN_FONT_SIZE` and it just doesn't make sense to me to set it there to `max_size`. I hope my logic is not wrong.
By the way, what if `max_size` IS -1? It's now at the same time (assuming that `min_size` is 1) `min_size` is exceeding `max_size` (because 1 > -1) and `min_size` CAN be less than 1, because you can set it then to -1?

PS. Yes, I could just create an issue but I just wanted to learn how Pull Requests work, so I made one. :) 